### PR TITLE
feat: ETHmxRewards real-time stakedBalanceOf

### DIFF
--- a/contracts/rewards/interfaces/IETHmxRewards.sol
+++ b/contracts/rewards/interfaces/IETHmxRewards.sol
@@ -22,6 +22,11 @@ interface IETHmxRewards {
 		view
 		returns (uint256);
 
+	function lastStakedBalanceOf(address account)
+		external
+		view
+		returns (uint256);
+
 	function lastTotalRewardsAccrued() external view returns (uint256);
 
 	function readyForUpdate() external view returns (bool);

--- a/test/rewards/ETHmxRewards/modules/stake.ts
+++ b/test/rewards/ETHmxRewards/modules/stake.ts
@@ -72,7 +72,14 @@ export default function run(): void {
 	it('should update stakedBalanceOf', async function () {
 		const { contract, deployer } = fixture;
 		await stake(fixture, stakeAmount);
-		expect(await contract.stakedBalanceOf(deployer)).to.eq(stakeAmount);
+		expect(
+			await contract.lastStakedBalanceOf(deployer),
+			'lastStakedBalanceOf mismatch',
+		).to.eq(stakeAmount);
+		expect(
+			await contract.stakedBalanceOf(deployer),
+			'stakedBalanceOf mismatch',
+		).to.eq(stakeAmount);
 	});
 
 	it('should update totalStaked', async function () {

--- a/test/rewards/ETHmxRewards/modules/unstake.ts
+++ b/test/rewards/ETHmxRewards/modules/unstake.ts
@@ -64,13 +64,27 @@ export default function run(): void {
 		it('when amount < updated stake', async function () {
 			const { contract, deployer } = fixture;
 			await contract.unstake(updatedStake.sub(1));
-			expect(await contract.stakedBalanceOf(deployer)).to.eq(1);
+			expect(
+				await contract.lastStakedBalanceOf(deployer),
+				'lastStakedBalanceOf mismatch',
+			).to.eq(1);
+			expect(
+				await contract.stakedBalanceOf(deployer),
+				'stakedBalanceOf mismatch',
+			).to.eq(1);
 		});
 
 		it('when amount > updated stake', async function () {
 			const { contract, deployer } = fixture;
 			await contract.unstake(updatedStake.add(1));
-			expect(await contract.stakedBalanceOf(deployer)).to.eq(0);
+			expect(
+				await contract.lastStakedBalanceOf(deployer),
+				'lastStakedBalanceOf mismatch',
+			).to.eq(0);
+			expect(
+				await contract.stakedBalanceOf(deployer),
+				'stakedBalanceOf mismatch',
+			).to.eq(0);
 		});
 	});
 

--- a/test/rewards/ETHmxRewards/modules/updateReward.ts
+++ b/test/rewards/ETHmxRewards/modules/updateReward.ts
@@ -79,7 +79,14 @@ export default function run(): void {
 		it('should update stakedBalanceOf', async function () {
 			const { contract, deployer } = fixture;
 			const expected = staked.sub(rewards);
-			expect(await contract.stakedBalanceOf(deployer)).to.eq(expected);
+			expect(
+				await contract.lastStakedBalanceOf(deployer),
+				'lastStakedBalanceOf mismatch',
+			).to.eq(expected);
+			expect(
+				await contract.stakedBalanceOf(deployer),
+				'stakedBalanceOf mismatch',
+			).to.eq(expected);
 		});
 
 		it('should update lastRewardsBalanceOf', async function () {
@@ -103,7 +110,14 @@ export default function run(): void {
 
 		it('should update stakedBalanceOf', async function () {
 			const { contract, deployer } = fixture;
-			expect(await contract.stakedBalanceOf(deployer)).to.eq(0);
+			expect(
+				await contract.lastStakedBalanceOf(deployer),
+				'lastStakedBalanceOf mismatch',
+			).to.eq(0);
+			expect(
+				await contract.stakedBalanceOf(deployer),
+				'stakedBalanceOf mismatch',
+			).to.eq(0);
 		});
 
 		it('should update lastRewardsBalanceOf', async function () {
@@ -125,8 +139,8 @@ export default function run(): void {
 		await contract.updateReward();
 
 		expect(
-			await contract.stakedBalanceOf(deployer),
-			'stakedBalanceOf mismatch',
+			await contract.lastStakedBalanceOf(deployer),
+			'lastStakedBalanceOf mismatch',
 		).to.eq(0);
 		expect(
 			await contract.lastRewardsBalanceOf(deployer),
@@ -188,15 +202,15 @@ export default function run(): void {
 				.and.lte(rewardsB);
 
 			expect(
-				await contract.stakedBalanceOf(deployer),
-				`checkpoint ${checkpoint}: deployer stakedBalanceOf mismatch`,
+				await contract.lastStakedBalanceOf(deployer),
+				`checkpoint ${checkpoint}: deployer lastStakedBalanceOf mismatch`,
 			)
 				.to.be.gte(stakeA.sub(error))
 				.and.lte(stakeA);
 
 			expect(
-				await contract.stakedBalanceOf(tester),
-				`checkpoint ${checkpoint}: tester stakedBalanceOf mismatch`,
+				await contract.lastStakedBalanceOf(tester),
+				`checkpoint ${checkpoint}: tester lastStakedBalanceOf mismatch`,
 			)
 				.to.be.gte(stakeB.sub(error))
 				.and.lte(stakeB);


### PR DESCRIPTION
stakedBalanceOf now updates as rewards are accrued, instead of only
after redeeming/(un)staking. lastStakedBalanceOf can be used to
retrieve state.